### PR TITLE
Observe scanner data latency

### DIFF
--- a/adaptio/src/main/weld_control/src/performance_metrics.cc
+++ b/adaptio/src/main/weld_control/src/performance_metrics.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "common/clock_functions.h"
+#include "common/logging/application_log.h"
 
 namespace weld_control {
 
@@ -25,6 +26,11 @@ void PerformanceMetrics::UpdateABWLatencyLpcs(uint64_t time_stamp) {
   auto scanner_data_time    = std::chrono::system_clock::time_point{std::chrono::nanoseconds{time_stamp}};
   auto latency              = now - scanner_data_time;
   auto latency_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(latency).count();
+
+  auto now_nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+  auto latency_seconds = std::chrono::duration<double>(latency).count();
+  LOG_DEBUG("ABW latency timestamps: now_ns={} scanner_ns={} latency_ms={} latency_s={}", now_nanoseconds,
+            time_stamp, latency_milliseconds, latency_seconds);
 
   abw_latency_lpcs_.Set(static_cast<double>(latency_milliseconds / 1000.0));
 }


### PR DESCRIPTION
Add debug logging for ABW latency timestamps to aid in debugging latency calculations.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b02f33a-db78-449c-bf70-be9810ca089c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b02f33a-db78-449c-bf70-be9810ca089c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

